### PR TITLE
Fix dashboard statistics and clickable filters - v1.0.4

### DIFF
--- a/LOADER-CORRECTED.html
+++ b/LOADER-CORRECTED.html
@@ -289,15 +289,15 @@
 </div>
 
 <!-- Load CSS from GitHub via jsDelivr CDN -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/styles.css?v=1.0.3">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/styles.css?v=1.0.4">
 
 <!-- Load JavaScript modules from GitHub via jsDelivr CDN -->
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/config.js?v=1.0.3"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/state.js?v=1.0.3"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/utils.js?v=1.0.3"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/api.js?v=1.0.3"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/ui.js?v=1.0.3"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/main.js?v=1.0.3"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/config.js?v=1.0.4"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/state.js?v=1.0.4"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/utils.js?v=1.0.4"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/api.js?v=1.0.4"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/ui.js?v=1.0.4"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/enhance-interface-usability-UKPeH/src/main.js?v=1.0.4"></script>
 
 <!--
    ✅ COMPLETE VERSION - Matches original Interface Tunergia.html exactly
@@ -314,7 +314,7 @@
    - Pagination controls
 
    🔄 UPDATED: Repository name changed to micro_crm_tunergia
-   📦 Version: 1.0.3 (Fixed data display issues)
+   📦 Version: 1.0.4 (Dashboard statistics + clickable filters working!)
 
    ⚠️ IMPORTANT: Your repo must be PUBLIC for jsDelivr to work!
    Check: https://github.com/pedrokrug/micro_crm_tunergia/settings

--- a/src/api.js
+++ b/src/api.js
@@ -27,12 +27,17 @@ window.TunergiaAPI = {
 
         let data = [];
 
-        // Case 1: Response has 'data' array (aggregated by Code node)
-        if (result && result.data && Array.isArray(result.data)) {
+        // Case 1: Array with first item containing data property (current n8n format)
+        if (Array.isArray(result) && result.length > 0 && result[0] && result[0].data) {
+            console.log('Found array[0].data with', result[0].data.length, 'items');
+            data = result[0].data;
+        }
+        // Case 2: Response has 'data' array (aggregated by Code node)
+        else if (result && result.data && Array.isArray(result.data)) {
             console.log('Found result.data array with', result.data.length, 'items');
             data = result.data;
         }
-        // Case 2: Direct array of results
+        // Case 3: Direct array of results
         else if (Array.isArray(result)) {
             console.log('Direct array response with', result.length, 'items');
             // Check if items have .json property (n8n format)
@@ -42,7 +47,7 @@ window.TunergiaAPI = {
                 data = result;
             }
         }
-        // Case 3: Single object (fallback for old format)
+        // Case 4: Single object (fallback for old format)
         else if (result && typeof result === 'object') {
             console.log('Single object response (old format)');
             if (result.id || result.estado || result.cups || result.cliente || result.total) {

--- a/src/main.js
+++ b/src/main.js
@@ -43,9 +43,12 @@
             // Step 2: Update user UI
             window.TunergiaUI.updateUserUI();
 
-            // Step 3: Load contracts
-            console.log('📋 Loading contracts...');
-            await window.TunergiaAPI.loadContracts();
+            // Step 3: Load dashboard data in parallel
+            console.log('📊 Loading dashboard data...');
+            await Promise.all([
+                window.TunergiaUI.updateStatistics(),
+                window.TunergiaAPI.loadContracts()
+            ]);
 
             const contractCount = window.getState('contracts').length;
             console.log(`✅ Loaded ${contractCount} contracts`);


### PR DESCRIPTION
Major fixes:
- Update api.js executeQuery() to handle array-wrapped response format
  * Now correctly parses: [{ data: [...], count: 13 }]
- Add complete dashboard statistics calculation to ui.js
  * Calculate Tramitados, Activados, Bajas (contracts & kWh)
  * Calculate percentage changes vs previous period
  * Update all 6 stat cards dynamically
- Add date filter button event listeners
  * 12 meses, 6 meses, 30 días, 7 días now clickable
  * Updates statistics when clicked
- Update main.js to load statistics in parallel with contracts
- Bump version to 1.0.4