### PR TITLE
Fix field name mismatches for history and documents display

### DIFF
--- a/LOADER-PROD.html
+++ b/LOADER-PROD.html
@@ -1,5 +1,5 @@
 <!--
-    Tunergia CRM - Production Loader v2.0.0
+    Tunergia CRM - Production Loader v2.0.1
 
     This file loads the modular CRM interface from GitHub CDN.
     Paste this entire content into Odoo HTML block.
@@ -11,11 +11,11 @@
     - src_prod/tunergia-ui.js (UI, Events, Main)
 
     Last updated: 2025-12-22
-    Version: 2.0.0
+    Version: 2.0.1
 -->
 
 <!-- CSS Styles -->
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/styles.css?v=2.0.0">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/styles.css?v=2.0.1">
 
 <!-- HTML Content -->
 <div class="tunergia-dashboard">
@@ -797,6 +797,6 @@
 </div>
 
 <!-- JavaScript Modules (load in order) -->
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-core.js?v=2.0.0"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-api.js?v=2.0.0"></script>
-<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-ui.js?v=2.0.0"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-core.js?v=2.0.1"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-api.js?v=2.0.1"></script>
+<script src="https://cdn.jsdelivr.net/gh/pedrokrug/micro_crm_tunergia@claude/review-project-strategy-hWTV1/src_prod/tunergia-ui.js?v=2.0.1"></script>

--- a/src_prod/tunergia-ui.js
+++ b/src_prod/tunergia-ui.js
@@ -383,7 +383,7 @@
 
         // Documents
         const docsContainer = document.getElementById('detailDocumentos');
-        const documentos = contract.documentos || [];
+        const documentos = contract.documentacion || [];
 
         if (documentos.length > 0) {
             docsContainer.innerHTML = documentos.map((doc, index) => {
@@ -418,7 +418,7 @@
 
     function renderHistory(contract) {
         const timeline = document.getElementById('historyTimeline');
-        const historialData = contract.historial || [];
+        const historialData = contract.historico || [];
 
         if (historialData.length === 0) {
             timeline.innerHTML = '<p class="no-history">No hay historial disponible para este contrato</p>';
@@ -429,7 +429,7 @@
             <div class="history-item">
                 <div class="history-date">${utils.formatDate(item.fecha)}</div>
                 <div class="history-action">${utils.escapeHtml(item.accion || item.action)}</div>
-                <div class="history-detail">${utils.escapeHtml(item.detalle || item.detail || '')}</div>
+                <div class="history-detail">${utils.escapeHtml(item.texto || item.detalle || '')}</div>
                 ${item.usuario ? `<div class="history-user">Por: ${utils.escapeHtml(item.usuario)}</div>` : ''}
             </div>
         `).join('');


### PR DESCRIPTION
- Fix contract.documentos → contract.documentacion (API returns documentacion)
- Fix contract.historial → contract.historico (API returns historico)
- Fix item.detalle → item.texto in history rendering (API returns texto)
- Bump version to 2.0.1 for cache-busting on CDN